### PR TITLE
Works on latest major Erlang releases + tests + dropping R16 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,7 @@ otp_release:
 matrix:
   fast_finish: true
   allow_failures:
-    - otp_release: 19.2
-    - otp_release: 18.3
-    - otp_release: 17.5
-    - otp_release: R16B03-1
+    - otp_release: R15B03
 
 install:
   - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3
@@ -31,19 +28,19 @@ script:
   - rebar3 compile
   - rebar3 xref
   # - rebar3 eunit
-  # - make S
+  - make S
   - make test_deforestation0
   - make test_deforestation1
   # - make test_deforestation2
   - make test_deforestation3
   - make test_deforestation4
-  # - make test_deforestation10
-  # - make test_unfold0
-  # - make test_unfold1
-  # - make test_unfold2
-  # - make test_unfold3
-  # - make test_unfold4
-  # - make test_unfold5
+  - make test_deforestation10
+  - make test_unfold0
+  - make test_unfold1
+  - make test_unfold2
+  - make test_unfold3
+  - make test_unfold4
+  - make test_unfold5
   - git add -A -f ebin/*.S
   - git --no-pager diff
   - git --no-pager diff --cached

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - otp_release: R15B03
+    - otp_release: R16B03-1
 
 install:
   - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   # - make test_deforestation2
   - make test_deforestation3
   # - make test_deforestation4
+  # - make test_deforestation10
   # - make test_unfold0
   # - make test_unfold1
   # - make test_unfold2

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   # - make test_deforestation2
   - make test_deforestation3
   - make test_deforestation4
-  - make test_deforestation10
+  # - make test_deforestation10
   # - make test_unfold0
   # - make test_unfold1
   # - make test_unfold2

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ script:
   - make
   - make S
   - make test_deforestation0
-  # - make test_deforestation1
+  - make test_deforestation1
   # - make test_deforestation2
   - make test_deforestation3
-  # - make test_deforestation4
-  # - make test_deforestation10
+  - make test_deforestation4
+  - make test_deforestation10
   # - make test_unfold0
   # - make test_unfold1
   # - make test_unfold2

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - make test_unfold1
   - make test_unfold2
   - make test_unfold3
-  - make test_unfold4
+  # - make test_unfold4
   - make test_unfold5
   - git add -A -f ebin/*.S
   - git --no-pager diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ otp_release:
   - 19.2
   - 18.3
   - 17.5
-  - R16B03
-  - R16B02
+  - R16B03-1
   - R15B03
-  - R14B04
 
 matrix:
   fast_finish: true
@@ -17,9 +15,7 @@ matrix:
     - otp_release: 19.2
     - otp_release: 18.3
     - otp_release: 17.5
-    - otp_release: R16B03
-    - otp_release: R16B02
-    - otp_release: R14B04
+    - otp_release: R16B03-1
 
 install:
   - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - rebar3 compile
   - rebar3 xref
   # - rebar3 eunit
-  - make S
+  # - make S
   - make test_deforestation0
   - make test_deforestation1
   # - make test_deforestation2

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   # - make
   - rebar3 compile
   - rebar3 xref
-  - rebar3 eunit
+  # - rebar3 eunit
   - make S
   - make test_deforestation0
   - make test_deforestation1

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,10 @@ before_script:
 
 script:
   - set -e
-  - make
+  # - make
+  - rebar3 compile
+  - rebar3 xref
+  - rebar3 eunit
   - make S
   - make test_deforestation0
   - make test_deforestation1

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test_%: $(OBJECTS)
 	$(ERLC) +to_asm test/$*.erl
 	git add -A -f ebin/$*.S ebin/$*_.S
 	git --no-pager diff --cached
+	$(ERLC) test/$*.erl
 	$(ERL) -eval 'R = $*:a(), R = $*:b().' -s init stop
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/$*.S ebin/$*_.S | wc -l) ]]'
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ all:
 clean:
 	$(if $(wildcard ebin/*.beam), rm ebin/*.beam)
 
+old: ebin $(patsubst src/%.erl,ebin/%.beam,$(wildcard src/*.erl)) $(wildcard src/*.hrl) Makefile
+ebin:
+	mkdir $@
+ebin/%.beam: src/%.erl
+	erlc -pa ebin -o ebin $?
+test.%: old
+	erlc -pa ebin -o ebin +'{parse_transform, erlang_supercompiler}' test/$*.erl
+
 ASM = $(wildcard test/deforestation*.erl test/unfold*.erl)
 
 PA = _build/default/lib/erlscp/ebin/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ebin:
 	mkdir $@
 ebin/%.beam: src/%.erl
 	erlc -pa ebin -o ebin -DLOG $?
+test-old: $(patsubst test/%.erl,test.%,$(ASM))
 test.%: old
 	erlc -pa ebin -o ebin +'{parse_transform, erlang_supercompiler}' test/$*.erl
 	$(ERL) -eval 'R = $*:a(), R = $*:b().' -s init stop

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,8 @@ test_%: $(OBJECTS)
 	$(SUPERC) test/$*.erl
 	mv ebin/$*.S ebin/$*_.S
 	$(ERLC) +to_asm test/$*.erl
-	git --no-pager diff -- ebin/$*.S ebin/$*_.S
-	git --no-pager diff || true
-	git status || true
-	cat ebin/deforestation1_.S || true
-	ls -lha ebin/deforestation1_.S || true
+	git add -A -f ebin/$*.S ebin/$*_.S
+	git --no-pager diff --cached
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/$*.S ebin/$*_.S | wc -l) ]]'
 
 S: $(patsubst test/%.erl,S_%,$(ASM))

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ test_%: $(OBJECTS)
 	$(SUPERC) test/$*.erl
 	mv ebin/$*.S ebin/$*_.S
 	$(ERLC) +to_asm test/$*.erl
-	# git --no-pager diff -- ebin/$*.S ebin/$*_.S
-	git --no-pager diff
-	git status
-	cat ebin/deforestation1_.S
-	ls -lha ebin/deforestation1_.S
+	git --no-pager diff -- ebin/$*.S ebin/$*_.S
+	git --no-pager diff || true
+	git status || true
+	cat ebin/deforestation1_.S || true
+	ls -lha ebin/deforestation1_.S || true
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/$*.S ebin/$*_.S | wc -l) ]]'
 
 S: $(patsubst test/%.erl,S_%,$(ASM))

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ test_%: $(OBJECTS)
 	# git --no-pager diff -- ebin/$*.S ebin/$*_.S
 	git --no-pager diff
 	git status
+	cat ebin/deforestation1_.S
+	ls -lha ebin/deforestation1_.S
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/$*.S ebin/$*_.S | wc -l) ]]'
 
 S: $(patsubst test/%.erl,S_%,$(ASM))

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ old: ebin $(patsubst src/%.erl,ebin/%.beam,$(wildcard src/*.erl)) $(wildcard src
 ebin:
 	mkdir $@
 ebin/%.beam: src/%.erl
-	erlc -pa ebin -o ebin $?
+	erlc -pa ebin -o ebin -DDEBUG $?
 test.%: old
 	erlc -pa ebin -o ebin +'{parse_transform, erlang_supercompiler}' test/$*.erl
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test_%: $(OBJECTS)
 	$(SUPERC) test/$*.erl
 	mv ebin/$*.S ebin/$*_.S
 	$(ERLC) +to_asm test/$*.erl
+	git --no-pager diff -- ebin/$*.S ebin/$*_.S
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/$*.S ebin/$*_.S | wc -l) ]]'
 
 S: $(patsubst test/%.erl,S_%,$(ASM))

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ old: ebin $(patsubst src/%.erl,ebin/%.beam,$(wildcard src/*.erl)) $(wildcard src
 ebin:
 	mkdir $@
 ebin/%.beam: src/%.erl
-	erlc -pa ebin -o ebin -DDEBUG $?
+	erlc -pa ebin -o ebin -DLOG $?
 test.%: old
 	erlc -pa ebin -o ebin +'{parse_transform, erlang_supercompiler}' test/$*.erl
 	$(ERL) -eval 'R = $*:a(), R = $*:b().' -s init stop

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test.%: old
 ASM = $(wildcard test/deforestation*.erl test/unfold*.erl)
 
 PA = _build/default/lib/erlscp/ebin/
-ERLC = erlc -o ebin -pa $(PA)
+ERLC = erlc -o ebin -pa $(PA) -pa ebin
 ERL  = erl -noshell -pa $(PA) -pa ebin +A0 -boot start_clean
 
 test: S $(patsubst test/%.erl,test_%,$(ASM))
@@ -24,7 +24,9 @@ test_%: $(OBJECTS)
 	$(SUPERC) test/$*.erl
 	mv ebin/$*.S ebin/$*_.S
 	$(ERLC) +to_asm test/$*.erl
-	git --no-pager diff -- ebin/$*.S ebin/$*_.S
+	# git --no-pager diff -- ebin/$*.S ebin/$*_.S
+	git --no-pager diff
+	git status
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/$*.S ebin/$*_.S | wc -l) ]]'
 
 S: $(patsubst test/%.erl,S_%,$(ASM))

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test_%: $(OBJECTS)
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/$*.S ebin/$*_.S | wc -l) ]]'
 
 S: $(patsubst test/%.erl,S_%,$(ASM))
+	git --no-pager diff -- ebin
 	bash -c '[[ 0 -eq $$(git status --porcelain ebin/*.S | wc -l) ]]'
 S_%: test/%.erl
 	$(ERLC) +to_asm test/$*.erl

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	rebar3 do compile,eunit
+	rebar3 do compile,eunit,xref
 
 clean:
 	$(if $(wildcard ebin/*.beam), rm ebin/*.beam)

--- a/ebin/deforestation10.S
+++ b/ebin/deforestation10.S
@@ -44,7 +44,7 @@
   {label,7}.
     {move,{atom,badarg},{x,0}}.
     {line,[{location,"test/deforestation10.erl",6}]}.
-    {call_ext,1,{extfunc,erlang,error,1}}.
+    {call_ext_last,1,{extfunc,erlang,error,1},1}.
 
 
 {function, b, 0, 9}.

--- a/ebin/deforestation10.S
+++ b/ebin/deforestation10.S
@@ -44,7 +44,7 @@
   {label,7}.
     {move,{atom,badarg},{x,0}}.
     {line,[{location,"test/deforestation10.erl",6}]}.
-    {call_ext_last,1,{extfunc,erlang,error,1},1}.
+    {call_ext,1,{extfunc,erlang,error,1}}.
 
 
 {function, b, 0, 9}.

--- a/ebin/deforestation10.S
+++ b/ebin/deforestation10.S
@@ -1,0 +1,104 @@
+{module, deforestation10}.  %% version = 0
+
+{exports, [{a,0},{a,1},{b,0},{b,1},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 18}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/deforestation10.erl",4}]}.
+    {func_info,{atom,deforestation10},{atom,a},0}.
+  {label,2}.
+    {move,{literal,[blip,blop,3]},{x,0}}.
+    {call_only,1,{f,4}}.
+
+
+{function, a, 1, 4}.
+  {label,3}.
+    {line,[{location,"test/deforestation10.erl",5}]}.
+    {func_info,{atom,deforestation10},{atom,a},1}.
+  {label,4}.
+    {allocate_zero,1,1}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {gc_bif,length,{f,0},1,[{x,0}],{x,1}}.
+    {move,{x,0},{y,0}}.
+    {move,{x,1},{x,0}}.
+    {move,{literal,[1,2]},{x,1}}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {call_ext,2,{extfunc,lists,member,2}}.
+    {test,is_atom,{f,7},[{x,0}]}.
+    {select_val,{x,0},{f,7},{list,[{atom,true},{f,5},{atom,false},{f,6}]}}.
+  {label,5}.
+    {move,{y,0},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",8}]}.
+    {call_ext_last,1,{extfunc,do,the_thing,1},1}.
+  {label,6}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",7}]}.
+    {call_ext_last,3,{extfunc,io,format,3},1}.
+  {label,7}.
+    {move,{atom,badarg},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {call_ext,1,{extfunc,erlang,error,1}}.
+
+
+{function, b, 0, 9}.
+  {label,8}.
+    {line,[{location,"test/deforestation10.erl",11}]}.
+    {func_info,{atom,deforestation10},{atom,b},0}.
+  {label,9}.
+    {move,{literal,[bla]},{x,0}}.
+    {call_only,1,{f,11}}.
+
+
+{function, b, 1, 11}.
+  {label,10}.
+    {line,[{location,"test/deforestation10.erl",12}]}.
+    {func_info,{atom,deforestation10},{atom,b},1}.
+  {label,11}.
+    {test,is_nonempty_list,{f,10},[{x,0}]}.
+    {get_list,{x,0},{x,1},{x,2}}.
+    {test,is_nonempty_list,{f,12},[{x,2}]}.
+    {get_list,{x,2},{x,1},{x,3}}.
+    {test,is_nil,{f,13},[{x,3}]}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",13}]}.
+    {call_ext_only,3,{extfunc,io,format,3}}.
+  {label,12}.
+    {test,is_nil,{f,13},[{x,2}]}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",12}]}.
+    {call_ext_only,3,{extfunc,io,format,3}}.
+  {label,13}.
+    {line,[{location,"test/deforestation10.erl",14}]}.
+    {call_ext_only,1,{extfunc,do,the_thing,1}}.
+
+
+{function, module_info, 0, 15}.
+  {label,14}.
+    {line,[]}.
+    {func_info,{atom,deforestation10},{atom,module_info},0}.
+  {label,15}.
+    {move,{atom,deforestation10},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 17}.
+  {label,16}.
+    {line,[]}.
+    {func_info,{atom,deforestation10},{atom,module_info},1}.
+  {label,17}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,deforestation10},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/ebin/deforestation10_.S
+++ b/ebin/deforestation10_.S
@@ -4,7 +4,7 @@
 
 {attributes, []}.
 
-{labels, 22}.
+{labels, 21}.
 
 
 {function, a, 0, 2}.
@@ -32,7 +32,7 @@
   {label,5}.
     {move,{atom,badarg},{x,0}}.
     {line,[{location,"test/deforestation10.erl",6}]}.
-    {call_ext_last,1,{extfunc,erlang,error,1},0}.
+    {call_ext,1,{extfunc,erlang,error,1}}.
 
 
 {function, a, 1, 7}.
@@ -63,7 +63,7 @@
   {label,10}.
     {move,{atom,badarg},{x,0}}.
     {line,[{location,"test/deforestation10.erl",6}]}.
-    {call_ext_last,1,{extfunc,erlang,error,1},1}.
+    {call_ext,1,{extfunc,erlang,error,1}}.
 
 
 {function, b, 0, 12}.
@@ -71,61 +71,55 @@
     {line,[{location,"test/deforestation10.erl",11}]}.
     {func_info,{atom,deforestation10},{atom,b},0}.
   {label,12}.
-    {move,{literal,[bla]},{x,0}}.
-    {test,is_nonempty_list,{f,13},[{x,0}]}.
-    {get_list,{x,0},{x,1},{x,2}}.
-    {test,is_nil,{f,13},[{x,2}]}.
     {move,{literal,"usage: ...\n"},{x,1}}.
     {move,nil,{x,2}}.
     {move,{atom,standard_error},{x,0}}.
     {line,[{location,"test/deforestation10.erl",12}]}.
     {call_ext_only,3,{extfunc,io,format,3}}.
+
+
+{function, b, 1, 14}.
   {label,13}.
-    if_end.
-
-
-{function, b, 1, 15}.
-  {label,14}.
     {line,[{location,"test/deforestation10.erl",12}]}.
     {func_info,{atom,deforestation10},{atom,b},1}.
-  {label,15}.
-    {test,is_nonempty_list,{f,14},[{x,0}]}.
+  {label,14}.
+    {test,is_nonempty_list,{f,13},[{x,0}]}.
     {get_list,{x,0},{x,1},{x,2}}.
-    {test,is_nonempty_list,{f,16},[{x,2}]}.
+    {test,is_nonempty_list,{f,15},[{x,2}]}.
     {get_list,{x,2},{x,1},{x,3}}.
-    {test,is_nil,{f,17},[{x,3}]}.
+    {test,is_nil,{f,16},[{x,3}]}.
     {move,{literal,"usage: ...\n"},{x,1}}.
     {move,nil,{x,2}}.
     {move,{atom,standard_error},{x,0}}.
     {line,[{location,"test/deforestation10.erl",13}]}.
     {call_ext_only,3,{extfunc,io,format,3}}.
-  {label,16}.
-    {test,is_nil,{f,17},[{x,2}]}.
+  {label,15}.
+    {test,is_nil,{f,16},[{x,2}]}.
     {move,{literal,"usage: ...\n"},{x,1}}.
     {move,nil,{x,2}}.
     {move,{atom,standard_error},{x,0}}.
     {line,[{location,"test/deforestation10.erl",12}]}.
     {call_ext_only,3,{extfunc,io,format,3}}.
-  {label,17}.
+  {label,16}.
     {line,[{location,"test/deforestation10.erl",14}]}.
     {call_ext_only,1,{extfunc,do,the_thing,1}}.
 
 
-{function, module_info, 0, 19}.
-  {label,18}.
+{function, module_info, 0, 18}.
+  {label,17}.
     {line,[]}.
     {func_info,{atom,deforestation10},{atom,module_info},0}.
-  {label,19}.
+  {label,18}.
     {move,{atom,deforestation10},{x,0}}.
     {line,[]}.
     {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
 
 
-{function, module_info, 1, 21}.
-  {label,20}.
+{function, module_info, 1, 20}.
+  {label,19}.
     {line,[]}.
     {func_info,{atom,deforestation10},{atom,module_info},1}.
-  {label,21}.
+  {label,20}.
     {move,{x,0},{x,1}}.
     {move,{atom,deforestation10},{x,0}}.
     {line,[]}.

--- a/ebin/deforestation10_.S
+++ b/ebin/deforestation10_.S
@@ -1,0 +1,132 @@
+{module, deforestation10}.  %% version = 0
+
+{exports, [{a,0},{a,1},{b,0},{b,1},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 22}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/deforestation10.erl",4}]}.
+    {func_info,{atom,deforestation10},{atom,a},0}.
+  {label,2}.
+    {allocate,0,0}.
+    {move,{literal,[1,2]},{x,1}}.
+    {move,{integer,3},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {call_ext,2,{extfunc,lists,member,2}}.
+    {test,is_atom,{f,5},[{x,0}]}.
+    {select_val,{x,0},{f,5},{list,[{atom,true},{f,3},{atom,false},{f,4}]}}.
+  {label,3}.
+    {move,{literal,[blip,blop,3]},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",8}]}.
+    {call_ext_last,1,{extfunc,do,the_thing,1},0}.
+  {label,4}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",7}]}.
+    {call_ext_last,3,{extfunc,io,format,3},0}.
+  {label,5}.
+    {move,{atom,badarg},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {call_ext_last,1,{extfunc,erlang,error,1},0}.
+
+
+{function, a, 1, 7}.
+  {label,6}.
+    {line,[{location,"test/deforestation10.erl",5}]}.
+    {func_info,{atom,deforestation10},{atom,a},1}.
+  {label,7}.
+    {allocate_zero,1,1}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {gc_bif,length,{f,0},1,[{x,0}],{x,1}}.
+    {move,{x,0},{y,0}}.
+    {move,{x,1},{x,0}}.
+    {move,{literal,[1,2]},{x,1}}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {call_ext,2,{extfunc,lists,member,2}}.
+    {test,is_atom,{f,10},[{x,0}]}.
+    {select_val,{x,0},{f,10},{list,[{atom,true},{f,8},{atom,false},{f,9}]}}.
+  {label,8}.
+    {move,{y,0},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",8}]}.
+    {call_ext_last,1,{extfunc,do,the_thing,1},1}.
+  {label,9}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",7}]}.
+    {call_ext_last,3,{extfunc,io,format,3},1}.
+  {label,10}.
+    {move,{atom,badarg},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",6}]}.
+    {call_ext_last,1,{extfunc,erlang,error,1},1}.
+
+
+{function, b, 0, 12}.
+  {label,11}.
+    {line,[{location,"test/deforestation10.erl",11}]}.
+    {func_info,{atom,deforestation10},{atom,b},0}.
+  {label,12}.
+    {move,{literal,[bla]},{x,0}}.
+    {test,is_nonempty_list,{f,13},[{x,0}]}.
+    {get_list,{x,0},{x,1},{x,2}}.
+    {test,is_nil,{f,13},[{x,2}]}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",12}]}.
+    {call_ext_only,3,{extfunc,io,format,3}}.
+  {label,13}.
+    if_end.
+
+
+{function, b, 1, 15}.
+  {label,14}.
+    {line,[{location,"test/deforestation10.erl",12}]}.
+    {func_info,{atom,deforestation10},{atom,b},1}.
+  {label,15}.
+    {test,is_nonempty_list,{f,14},[{x,0}]}.
+    {get_list,{x,0},{x,1},{x,2}}.
+    {test,is_nonempty_list,{f,16},[{x,2}]}.
+    {get_list,{x,2},{x,1},{x,3}}.
+    {test,is_nil,{f,17},[{x,3}]}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",13}]}.
+    {call_ext_only,3,{extfunc,io,format,3}}.
+  {label,16}.
+    {test,is_nil,{f,17},[{x,2}]}.
+    {move,{literal,"usage: ...\n"},{x,1}}.
+    {move,nil,{x,2}}.
+    {move,{atom,standard_error},{x,0}}.
+    {line,[{location,"test/deforestation10.erl",12}]}.
+    {call_ext_only,3,{extfunc,io,format,3}}.
+  {label,17}.
+    {line,[{location,"test/deforestation10.erl",14}]}.
+    {call_ext_only,1,{extfunc,do,the_thing,1}}.
+
+
+{function, module_info, 0, 19}.
+  {label,18}.
+    {line,[]}.
+    {func_info,{atom,deforestation10},{atom,module_info},0}.
+  {label,19}.
+    {move,{atom,deforestation10},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 21}.
+  {label,20}.
+    {line,[]}.
+    {func_info,{atom,deforestation10},{atom,module_info},1}.
+  {label,21}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,deforestation10},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/ebin/deforestation1_.S
+++ b/ebin/deforestation1_.S
@@ -1,7 +1,12 @@
 {module, deforestation1}.  %% version = 0
+
 {exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+
 {attributes, []}.
+
 {labels, 9}.
+
+
 {function, a, 0, 2}.
   {label,1}.
     {line,[{location,"test/deforestation1.erl",4}]}.
@@ -9,6 +14,8 @@
   {label,2}.
     {move,{literal,"0.1.0"},{x,0}}.
     return.
+
+
 {function, b, 0, 4}.
   {label,3}.
     {line,[{location,"test/deforestation1.erl",6}]}.
@@ -16,6 +23,8 @@
   {label,4}.
     {move,{literal,"0.1.0"},{x,0}}.
     return.
+
+
 {function, module_info, 0, 6}.
   {label,5}.
     {line,[]}.
@@ -24,6 +33,8 @@
     {move,{atom,deforestation1},{x,0}}.
     {line,[]}.
     {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
 {function, module_info, 1, 8}.
   {label,7}.
     {line,[]}.

--- a/ebin/deforestation1_.S
+++ b/ebin/deforestation1_.S
@@ -1,0 +1,35 @@
+{module, deforestation1}.  %% version = 0
+{exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+{attributes, []}.
+{labels, 9}.
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/deforestation1.erl",4}]}.
+    {func_info,{atom,deforestation1},{atom,a},0}.
+  {label,2}.
+    {move,{literal,"0.1.0"},{x,0}}.
+    return.
+{function, b, 0, 4}.
+  {label,3}.
+    {line,[{location,"test/deforestation1.erl",6}]}.
+    {func_info,{atom,deforestation1},{atom,b},0}.
+  {label,4}.
+    {move,{literal,"0.1.0"},{x,0}}.
+    return.
+{function, module_info, 0, 6}.
+  {label,5}.
+    {line,[]}.
+    {func_info,{atom,deforestation1},{atom,module_info},0}.
+  {label,6}.
+    {move,{atom,deforestation1},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+{function, module_info, 1, 8}.
+  {label,7}.
+    {line,[]}.
+    {func_info,{atom,deforestation1},{atom,module_info},1}.
+  {label,8}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,deforestation1},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/ebin/deforestation4_.S
+++ b/ebin/deforestation4_.S
@@ -1,0 +1,47 @@
+{module, deforestation4}.  %% version = 0
+
+{exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 9}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/deforestation4.erl",6}]}.
+    {func_info,{atom,deforestation4},{atom,a},0}.
+  {label,2}.
+    {move,{literal,["app [","my_app",<<"]">>]},{x,0}}.
+    {line,[{location,"test/deforestation4.erl",6}]}.
+    {call_ext_only,1,{extfunc,erlang,iolist_to_binary,1}}.
+
+
+{function, b, 0, 4}.
+  {label,3}.
+    {line,[{location,"test/deforestation4.erl",8}]}.
+    {func_info,{atom,deforestation4},{atom,b},0}.
+  {label,4}.
+    {move,{literal,<<"app [my_app]">>},{x,0}}.
+    return.
+
+
+{function, module_info, 0, 6}.
+  {label,5}.
+    {line,[]}.
+    {func_info,{atom,deforestation4},{atom,module_info},0}.
+  {label,6}.
+    {move,{atom,deforestation4},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 8}.
+  {label,7}.
+    {line,[]}.
+    {func_info,{atom,deforestation4},{atom,module_info},1}.
+  {label,8}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,deforestation4},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/ebin/unfold0_.S
+++ b/ebin/unfold0_.S
@@ -1,0 +1,127 @@
+{module, unfold0}.  %% version = 0
+
+{exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 19}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/unfold0.erl",6}]}.
+    {func_info,{atom,unfold0},{atom,a},0}.
+  {label,2}.
+    {allocate_zero,4,0}.
+    {make_fun2,{f,18},0,0,0}.
+    {move,{x,0},{y,3}}.
+    {make_fun2,{f,16},0,0,0}.
+    {move,{x,0},{y,2}}.
+    {make_fun2,{f,14},0,0,0}.
+    {move,{x,0},{y,1}}.
+    {make_fun2,{f,12},0,0,0}.
+    {move,{x,0},{y,0}}.
+    {make_fun2,{f,10},0,0,0}.
+    {test_heap,8,1}.
+    {put_list,{x,0},nil,{x,3}}.
+    {put_list,{y,0},{x,3},{x,3}}.
+    {put_list,{y,1},{x,3},{x,3}}.
+    {put_list,{y,2},{x,3},{x,2}}.
+    {move,{literal,{r,undefined,undefined,undefined,undefined,undefined}},
+          {x,1}}.
+    {move,{y,3},{x,0}}.
+    {line,[{location,"test/unfold0.erl",12}]}.
+    {call_ext_last,3,{extfunc,lists,foldl,3},4}.
+
+
+{function, b, 0, 4}.
+  {label,3}.
+    {line,[{location,"test/unfold0.erl",14}]}.
+    {func_info,{atom,unfold0},{atom,b},0}.
+  {label,4}.
+    {move,{literal,{r,undefined,"DEUX","trois",undefined,"cinq"}},{x,0}}.
+    return.
+
+
+{function, module_info, 0, 6}.
+  {label,5}.
+    {line,[]}.
+    {func_info,{atom,unfold0},{atom,module_info},0}.
+  {label,6}.
+    {move,{atom,unfold0},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 8}.
+  {label,7}.
+    {line,[]}.
+    {func_info,{atom,unfold0},{atom,module_info},1}.
+  {label,8}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,unfold0},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.
+
+
+{function, '-a/0-fun-4-', 1, 10}.
+  {label,9}.
+    {line,[{location,"test/unfold0.erl",10}]}.
+    {func_info,{atom,unfold0},{atom,'-a/0-fun-4-'},1}.
+  {label,10}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"DEUX"},{x,2}}.
+    {move,{integer,3},{x,0}}.
+    {line,[{location,"test/unfold0.erl",10}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-3-', 1, 12}.
+  {label,11}.
+    {line,[{location,"test/unfold0.erl",9}]}.
+    {func_info,{atom,unfold0},{atom,'-a/0-fun-3-'},1}.
+  {label,12}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"cinq"},{x,2}}.
+    {move,{integer,6},{x,0}}.
+    {line,[{location,"test/unfold0.erl",9}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-2-', 1, 14}.
+  {label,13}.
+    {line,[{location,"test/unfold0.erl",8}]}.
+    {func_info,{atom,unfold0},{atom,'-a/0-fun-2-'},1}.
+  {label,14}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"trois"},{x,2}}.
+    {move,{integer,4},{x,0}}.
+    {line,[{location,"test/unfold0.erl",8}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-1-', 1, 16}.
+  {label,15}.
+    {line,[{location,"test/unfold0.erl",7}]}.
+    {func_info,{atom,unfold0},{atom,'-a/0-fun-1-'},1}.
+  {label,16}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"deux"},{x,2}}.
+    {move,{integer,3},{x,0}}.
+    {line,[{location,"test/unfold0.erl",7}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-0-', 2, 18}.
+  {label,17}.
+    {line,[{location,"test/unfold0.erl",12}]}.
+    {func_info,{atom,unfold0},{atom,'-a/0-fun-0-'},2}.
+  {label,18}.
+    {allocate,0,2}.
+    {move,{x,1},{x,2}}.
+    {move,{x,0},{x,1}}.
+    {move,{x,2},{x,0}}.
+    {line,[{location,"test/unfold0.erl",12}]}.
+    {call_fun,1}.
+    {deallocate,0}.
+    return.

--- a/ebin/unfold1_.S
+++ b/ebin/unfold1_.S
@@ -1,0 +1,46 @@
+{module, unfold1}.  %% version = 0
+
+{exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 9}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/unfold1.erl",6}]}.
+    {func_info,{atom,unfold1},{atom,a},0}.
+  {label,2}.
+    {move,{literal,{r,undefined,"DEUX","trois",undefined,"cinq"}},{x,0}}.
+    return.
+
+
+{function, b, 0, 4}.
+  {label,3}.
+    {line,[{location,"test/unfold1.erl",14}]}.
+    {func_info,{atom,unfold1},{atom,b},0}.
+  {label,4}.
+    {move,{literal,{r,undefined,"DEUX","trois",undefined,"cinq"}},{x,0}}.
+    return.
+
+
+{function, module_info, 0, 6}.
+  {label,5}.
+    {line,[]}.
+    {func_info,{atom,unfold1},{atom,module_info},0}.
+  {label,6}.
+    {move,{atom,unfold1},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 8}.
+  {label,7}.
+    {line,[]}.
+    {func_info,{atom,unfold1},{atom,module_info},1}.
+  {label,8}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,unfold1},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/ebin/unfold2_.S
+++ b/ebin/unfold2_.S
@@ -1,0 +1,127 @@
+{module, unfold2}.  %% version = 0
+
+{exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 19}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/unfold2.erl",6}]}.
+    {func_info,{atom,unfold2},{atom,a},0}.
+  {label,2}.
+    {allocate_zero,4,0}.
+    {make_fun2,{f,18},0,0,0}.
+    {move,{x,0},{y,3}}.
+    {make_fun2,{f,16},0,0,0}.
+    {move,{x,0},{y,2}}.
+    {make_fun2,{f,14},0,0,0}.
+    {move,{x,0},{y,1}}.
+    {make_fun2,{f,12},0,0,0}.
+    {move,{x,0},{y,0}}.
+    {make_fun2,{f,10},0,0,0}.
+    {test_heap,8,1}.
+    {put_list,{x,0},nil,{x,3}}.
+    {put_list,{y,0},{x,3},{x,3}}.
+    {put_list,{y,1},{x,3},{x,3}}.
+    {put_list,{y,2},{x,3},{x,2}}.
+    {move,{literal,{r,undefined,undefined,undefined,undefined,undefined}},
+          {x,1}}.
+    {move,{y,3},{x,0}}.
+    {line,[{location,"test/unfold2.erl",12}]}.
+    {call_ext_last,3,{extfunc,lists,foldl,3},4}.
+
+
+{function, b, 0, 4}.
+  {label,3}.
+    {line,[{location,"test/unfold2.erl",19}]}.
+    {func_info,{atom,unfold2},{atom,b},0}.
+  {label,4}.
+    {move,{literal,{r,undefined,"DEUX","trois",undefined,"cinq"}},{x,0}}.
+    return.
+
+
+{function, module_info, 0, 6}.
+  {label,5}.
+    {line,[]}.
+    {func_info,{atom,unfold2},{atom,module_info},0}.
+  {label,6}.
+    {move,{atom,unfold2},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 8}.
+  {label,7}.
+    {line,[]}.
+    {func_info,{atom,unfold2},{atom,module_info},1}.
+  {label,8}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,unfold2},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.
+
+
+{function, '-a/0-fun-4-', 1, 10}.
+  {label,9}.
+    {line,[{location,"test/unfold2.erl",15}]}.
+    {func_info,{atom,unfold2},{atom,'-a/0-fun-4-'},1}.
+  {label,10}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"DEUX"},{x,2}}.
+    {move,{integer,3},{x,0}}.
+    {line,[{location,"test/unfold2.erl",15}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-3-', 1, 12}.
+  {label,11}.
+    {line,[{location,"test/unfold2.erl",17}]}.
+    {func_info,{atom,unfold2},{atom,'-a/0-fun-3-'},1}.
+  {label,12}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"cinq"},{x,2}}.
+    {move,{integer,6},{x,0}}.
+    {line,[{location,"test/unfold2.erl",17}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-2-', 1, 14}.
+  {label,13}.
+    {line,[{location,"test/unfold2.erl",16}]}.
+    {func_info,{atom,unfold2},{atom,'-a/0-fun-2-'},1}.
+  {label,14}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"trois"},{x,2}}.
+    {move,{integer,4},{x,0}}.
+    {line,[{location,"test/unfold2.erl",16}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-1-', 1, 16}.
+  {label,15}.
+    {line,[{location,"test/unfold2.erl",14}]}.
+    {func_info,{atom,unfold2},{atom,'-a/0-fun-1-'},1}.
+  {label,16}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"deux"},{x,2}}.
+    {move,{integer,3},{x,0}}.
+    {line,[{location,"test/unfold2.erl",14}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-0-', 2, 18}.
+  {label,17}.
+    {line,[{location,"test/unfold2.erl",12}]}.
+    {func_info,{atom,unfold2},{atom,'-a/0-fun-0-'},2}.
+  {label,18}.
+    {allocate,0,2}.
+    {move,{x,1},{x,2}}.
+    {move,{x,0},{x,1}}.
+    {move,{x,2},{x,0}}.
+    {line,[{location,"test/unfold2.erl",12}]}.
+    {call_fun,1}.
+    {deallocate,0}.
+    return.

--- a/ebin/unfold3_.S
+++ b/ebin/unfold3_.S
@@ -1,0 +1,127 @@
+{module, unfold3}.  %% version = 0
+
+{exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 19}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/unfold3.erl",6}]}.
+    {func_info,{atom,unfold3},{atom,a},0}.
+  {label,2}.
+    {allocate_zero,4,0}.
+    {make_fun2,{f,18},0,0,0}.
+    {move,{x,0},{y,3}}.
+    {make_fun2,{f,16},0,0,0}.
+    {move,{x,0},{y,2}}.
+    {make_fun2,{f,14},0,0,0}.
+    {move,{x,0},{y,1}}.
+    {make_fun2,{f,12},0,0,0}.
+    {move,{x,0},{y,0}}.
+    {make_fun2,{f,10},0,0,0}.
+    {test_heap,8,1}.
+    {put_list,{x,0},nil,{x,3}}.
+    {put_list,{y,0},{x,3},{x,3}}.
+    {put_list,{y,1},{x,3},{x,3}}.
+    {put_list,{y,2},{x,3},{x,2}}.
+    {move,{literal,{r,undefined,undefined,undefined,undefined,undefined}},
+          {x,1}}.
+    {move,{y,3},{x,0}}.
+    {line,[{location,"test/unfold3.erl",15}]}.
+    {call_ext_last,3,{extfunc,lists,foldl,3},4}.
+
+
+{function, b, 0, 4}.
+  {label,3}.
+    {line,[{location,"test/unfold3.erl",22}]}.
+    {func_info,{atom,unfold3},{atom,b},0}.
+  {label,4}.
+    {move,{literal,{r,undefined,"DEUX","trois",undefined,"cinq"}},{x,0}}.
+    return.
+
+
+{function, module_info, 0, 6}.
+  {label,5}.
+    {line,[]}.
+    {func_info,{atom,unfold3},{atom,module_info},0}.
+  {label,6}.
+    {move,{atom,unfold3},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 8}.
+  {label,7}.
+    {line,[]}.
+    {func_info,{atom,unfold3},{atom,module_info},1}.
+  {label,8}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,unfold3},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.
+
+
+{function, '-a/0-fun-4-', 1, 10}.
+  {label,9}.
+    {line,[{location,"test/unfold3.erl",18}]}.
+    {func_info,{atom,unfold3},{atom,'-a/0-fun-4-'},1}.
+  {label,10}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"DEUX"},{x,2}}.
+    {move,{integer,3},{x,0}}.
+    {line,[{location,"test/unfold3.erl",18}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-3-', 1, 12}.
+  {label,11}.
+    {line,[{location,"test/unfold3.erl",20}]}.
+    {func_info,{atom,unfold3},{atom,'-a/0-fun-3-'},1}.
+  {label,12}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"cinq"},{x,2}}.
+    {move,{integer,6},{x,0}}.
+    {line,[{location,"test/unfold3.erl",20}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-2-', 1, 14}.
+  {label,13}.
+    {line,[{location,"test/unfold3.erl",19}]}.
+    {func_info,{atom,unfold3},{atom,'-a/0-fun-2-'},1}.
+  {label,14}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"trois"},{x,2}}.
+    {move,{integer,4},{x,0}}.
+    {line,[{location,"test/unfold3.erl",19}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-1-', 1, 16}.
+  {label,15}.
+    {line,[{location,"test/unfold3.erl",17}]}.
+    {func_info,{atom,unfold3},{atom,'-a/0-fun-1-'},1}.
+  {label,16}.
+    {move,{x,0},{x,1}}.
+    {move,{literal,"deux"},{x,2}}.
+    {move,{integer,3},{x,0}}.
+    {line,[{location,"test/unfold3.erl",17}]}.
+    {call_ext_only,3,{extfunc,erlang,setelement,3}}.
+
+
+{function, '-a/0-fun-0-', 2, 18}.
+  {label,17}.
+    {line,[{location,"test/unfold3.erl",15}]}.
+    {func_info,{atom,unfold3},{atom,'-a/0-fun-0-'},2}.
+  {label,18}.
+    {allocate,0,2}.
+    {move,{x,1},{x,2}}.
+    {move,{x,0},{x,1}}.
+    {move,{x,2},{x,0}}.
+    {line,[{location,"test/unfold3.erl",15}]}.
+    {call_fun,1}.
+    {deallocate,0}.
+    return.

--- a/ebin/unfold5_.S
+++ b/ebin/unfold5_.S
@@ -1,0 +1,46 @@
+{module, unfold5}.  %% version = 0
+
+{exports, [{a,0},{b,0},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 9}.
+
+
+{function, a, 0, 2}.
+  {label,1}.
+    {line,[{location,"test/unfold5.erl",6}]}.
+    {func_info,{atom,unfold5},{atom,a},0}.
+  {label,2}.
+    {move,{literal,{r,undefined,"DEUX","trois",undefined,"cinq"}},{x,0}}.
+    return.
+
+
+{function, b, 0, 4}.
+  {label,3}.
+    {line,[{location,"test/unfold5.erl",14}]}.
+    {func_info,{atom,unfold5},{atom,b},0}.
+  {label,4}.
+    {move,{literal,{r,undefined,"DEUX","trois",undefined,"cinq"}},{x,0}}.
+    return.
+
+
+{function, module_info, 0, 6}.
+  {label,5}.
+    {line,[]}.
+    {func_info,{atom,unfold5},{atom,module_info},0}.
+  {label,6}.
+    {move,{atom,unfold5},{x,0}}.
+    {line,[]}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 8}.
+  {label,7}.
+    {line,[]}.
+    {func_info,{atom,unfold5},{atom,module_info},1}.
+  {label,8}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,unfold5},{x,0}}.
+    {line,[]}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,3 @@
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls
               ]}.
-
-{deps, [{parse_trans, "3.0.0"}
-       ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -5,3 +5,8 @@
 	   ]}.
 
 {xref_warnings, true}.
+{xref_checks, [undefined_function_calls
+              ]}.
+
+{deps, [{parse_trans, "3.0.0"}
+       ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,6 @@
-[].
+{"1.1.0",
+[{<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.0.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"parse_trans">>, <<"9E96B1C9C3A0DF54E7B76F8F685D38BFA1EB21B31E042B1D1A5A70258E4DB1E3">>}]}
+].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,1 @@
-{"1.1.0",
-[{<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.0.0">>},0}]}.
-[
-{pkg_hash,[
- {<<"parse_trans">>, <<"9E96B1C9C3A0DF54E7B76F8F685D38BFA1EB21B31E042B1D1A5A70258E4DB1E3">>}]}
-].
+[].

--- a/src/erlang_supercompiler.erl
+++ b/src/erlang_supercompiler.erl
@@ -47,6 +47,7 @@ parse_transform(Forms0, _Options) ->
     ?DEBUG("After: ~p~n", [Ret0]),
     Ret = lists:takewhile(fun ({eof,_}) -> false; (_) -> true end, Ret0),
     %%FIXME: do not generate forms after emitting eof in the first place.
+    %%Note: this does not happen on R15B03.
     ?DEBUG("Really after: ~p~n", [Ret]),
     Ret.
 

--- a/src/erlang_supercompiler.erl
+++ b/src/erlang_supercompiler.erl
@@ -56,20 +56,19 @@ form(F={function,_,Name,Arity,_Clauses0}, Env0) ->
     %% functions are exported)?
     ?DEBUG("~n~nLooking at function: ~w/~w~n", [Name, Arity]),
     Expr0 = scp_expr:function_to_fun(F),
-    Seen = sets:union(Env0#env.seen_vars,
-                      erl_syntax_lib:variables(Expr0)),
-    Env1 = Env0#env{bound = sets:new(),
-                    seen_vars = Seen,
-                    w=[], ls=[], found=[],
-                    name = atom_to_list(Name),
-                    whistle_enabled =
-                        not sets:is_element({Name,Arity},
-                                            Env0#env.no_whistling)},
+    Seen = sets:union(Env0#env.seen_vars, erl_syntax_lib:variables(Expr0)),
+    Env1 = Env0#env{bound = sets:new()
+                   ,seen_vars = Seen
+                   ,w=[], ls=[], found=[]
+                   ,name = atom_to_list(Name)
+                   ,whistle_enabled = not sets:is_element({Name,Arity}, Env0#env.no_whistling)
+                   },
     {Env2,Expr1} = scp_expr:alpha_convert(Env1, Expr0),
     {Env,Expr2} = scp_main:drive(Env2, Expr1, []),
     {Expr,Letrecs} = scp_expr:extract_letrecs(Expr2),
-    Functions = [ scp_expr:fun_to_function(scp_tidy:function(Ex), Na, Ar) ||
-                    {Na, Ar, Ex} <- Letrecs ],
+    Functions = [scp_expr:fun_to_function(scp_tidy:function(Ex), Na, Ar)
+                 || {Na, Ar, Ex} <- Letrecs
+                ],
     Function = scp_expr:fun_to_function(scp_tidy:function(Expr), Name, Arity),
     {[Function|Functions],Env};
 form(X, Env) ->

--- a/src/erlang_supercompiler.erl
+++ b/src/erlang_supercompiler.erl
@@ -43,8 +43,11 @@ parse_transform(Forms0, _Options) ->
                 seen_vars = function_names(Forms),
                 no_whistling = sets:from_list(NoWhistling),
                 libnames = Libnames},
-    Ret = forms(Forms, Env1),
-    ?DEBUG("After: ~p~n", [Ret]),
+    Ret0 = forms(Forms, Env1),
+    ?DEBUG("After: ~p~n", [Ret0]),
+    Ret = lists:takewhile(fun ({eof,_}) -> false; (_) -> true end, Ret0),
+    %%FIXME: do not generate forms after emitting eof in the first place.
+    ?DEBUG("Really after: ~p~n", [Ret]),
     Ret.
 
 forms(Forms0, Env) ->

--- a/src/scp.hrl
+++ b/src/scp.hrl
@@ -62,5 +62,8 @@
         ?IS_CONST_TYPE(element(1,E));
             element(1,E)=='tuple', element(3,E)==[]).
 
-%%-define(DEBUG(P,A), (io:fwrite(P,A))).
+-ifdef(LOG).
+-define(DEBUG(P,A), (io:fwrite(P,A))).
+-else.
 -define(DEBUG(P,A), (false)).
+-endif.

--- a/src/scp_expr.erl
+++ b/src/scp_expr.erl
@@ -254,6 +254,7 @@ ac(Env,S,E={var,L,V}) ->
 ac(Env,S,E={integer,_,_}) -> {Env,S,E};
 ac(Env,S,E={float,_,_}) -> {Env,S,E};
 ac(Env,S,E={atom,_,_}) -> {Env,S,E};
+ac(Env,S,E={bin,_,_}) -> {Env,S,E};
 ac(Env,S,E={string,_,_}) -> {Env,S,E};
 ac(Env,S,E={char,_,_}) -> {Env,S,E};
 ac(Env,S,E={nil,_}) -> {Env,S,E};

--- a/src/scp_expr.erl
+++ b/src/scp_expr.erl
@@ -321,7 +321,13 @@ ac(Env0,S0,{block,L,[A0,B0]}) ->
     %% Variables defined in A are bound in B.
     {Env1,S1,A} = ac(Env0,S0,A0),
     {Env,S,B} = ac(Env1,S1,B0),
-    {Env,S,{block,L,[A,B]}}.
+    {Env,S,{block,L,[A,B]}};
+
+ac(Env, S, Expr) ->
+    io:format("~s:ac/3 Env ~p\n", [?MODULE, Env]),
+    io:format("~s:ac/3 S ~p\n", [?MODULE, S]),
+    io:format("~s:ac/3 Expr ~p\n", [?MODULE, Expr]),
+    throw(badimpl).
 
 ac_list(Env0,S0,[E0|Es0]) ->
     %% The rule here is that definitions made in expressions are

--- a/src/scp_expr.erl
+++ b/src/scp_expr.erl
@@ -274,6 +274,7 @@ ac(Env0,S0,{tuple,L,Es0}) ->
     {Env,S,Es} = ac_list(Env0,S0,Es0),
     {Env,S,{tuple,L,Es}};
 
+ac(Env,S,E={record,_,_,_}) -> {Env,S,E};
 ac(Env0,S0,{record_field,L,R0,F0}) ->
     {Env,S,[R,F]} = ac_list(Env0,S0,[R0,F0]),
     {Env,S,{record_field,L,R,F}};

--- a/test/deforestation10.erl
+++ b/test/deforestation10.erl
@@ -1,0 +1,14 @@
+-module(deforestation10).
+-export([a/0, b/0, a/1, b/1]).
+
+a() -> a([blip, blop, 3]).
+a(Args) ->
+    case not lists:member(length(Args), [1,2]) of
+        true -> io:format(standard_error, "usage: ...\n", []);
+        false -> do:the_thing(Args)
+    end.
+
+b() -> b([bla]).
+b([_]) -> io:format(standard_error, "usage: ...\n", []);
+b([_,_]) -> io:format(standard_error, "usage: ...\n", []);
+b([_|_]=Args) -> do:the_thing(Args).


### PR DESCRIPTION
The initial idea was to do a rewrite using `parse_trans` but it hasn't turn out that way yet.