### PR TITLE
export compile/1

### DIFF
--- a/src/erl_compile2.erl
+++ b/src/erl_compile2.erl
@@ -22,7 +22,7 @@
 -include_lib("stdlib/include/erl_compile.hrl").
 -include_lib("kernel/include/file.hrl").
 
--export([compile_cmdline/1]).
+-export([compile_cmdline/1, compile/1]).
 
 -export_type([cmd_line_arg/0]).
 


### PR DESCRIPTION
Seems it is implemented as a command line tool.
Since `compile_cmdline/1` calling erlang:halt() internally,  there is noway to call the this function without exiting my whole program by stopping the VM. 

Is it possible to export the `compile/1` so that we could use it without stopping VM?
My use case is to call `compile/1` on different erlang files.

I got this idea from this [stackoverflow question](https://stackoverflow.com/questions/64851796/is-it-possible-to-call-a-function-which-internally-calls-halt-without-haltin).